### PR TITLE
point_traits for point access

### DIFF
--- a/cukd/common.h
+++ b/cukd/common.h
@@ -279,12 +279,16 @@ namespace cukd {
       return s.substr(s.size()-suffix.size()) == suffix;
     }
 
+    /*! Point trait. Must provide the following members:
+       - numDims (int): the number of dimensions used in the kdtree (i.e.
+         without the payload).
+       - scalar_t (type): the scalar type used by the point (float usually).
+       - scalar_t getCoord(const point_t &p, int dim): static function that
+         returns the dim-th coord of the point.
+       - void setCoord(point_t &p, int dim, scalar_t value): static function
+         that sets the dim-th coord of the point.
+    */
     template<typename T> struct point_traits;
-
-    template<> struct point_traits<float3> { enum { numDims = 3 }; using scalar_t = float; };
-    template<> struct point_traits<float4> { enum { numDims = 4 }; using scalar_t = float; };
-
-    template<typename point_t> struct box_t { point_t lower, upper; };
 
     /*! Trivial implementation of the point interface for those kinds of
       point types where the first K elements are the K-dimensional
@@ -294,17 +298,29 @@ namespace cukd {
       the x and y coordinates are the point coordinates, and z and w
       are any other payload that does not get considered during the
       (2-d) construction) */
-    template<typename _point_t>
+    template<typename _point_t, typename _scalar_t>
     struct TrivialPointInterface
     {
-      typedef _point_t point_t;
-      using scalar_t = typename point_traits<point_t>::scalar_t;
-      
       inline static __host__ __device__
-      scalar_t get(const point_t &p, int dim) { return ((scalar_t*)&p)[dim]; }
+      _scalar_t getCoord(const _point_t &p, int dim) { return ((_scalar_t*)&p)[dim]; }
       inline static __host__ __device__
-      scalar_t& get(point_t &p, int dim) { return ((scalar_t*)&p)[dim]; }
+      void setCoord(_point_t &p, int dim, _scalar_t value) { ((_scalar_t*)&p)[dim] = value; }
     };
+
+    /*! Trivial point traits that will work for most float type points, e.g.
+      float3 and float4. Provided for convenience to make it easy to define
+      the point_traits for such points. */
+    template<typename point_t, int _numDims = sizeof(point_t) / sizeof(float)>
+    struct TrivialFloatPointTraits : TrivialPointInterface<point_t, float>
+    {
+      enum { numDims = _numDims };
+      using scalar_t = float;
+    };
+
+    template<> struct point_traits<float3> : TrivialFloatPointTraits<float3>{};
+    template<> struct point_traits<float4> : TrivialFloatPointTraits<float4>{};
+
+    template<typename point_t> struct box_t { point_t lower, upper; };
 
     /*! Extract a query_point_t from the node_point_t.
      * The dimension of the query_point_t must be no larger than the dimension
@@ -314,44 +330,24 @@ namespace cukd {
      */
     template<
       typename query_point_t = float4,
-      typename node_point_t = float4,
-      typename scalar_t = float,
-      typename QueryPointInterface = TrivialPointInterface<query_point_t>,
-      typename NodePointInterface = TrivialPointInterface<node_point_t>>
+      typename node_point_t = float4>
     inline __host__ __device__
-    query_point_t extractPosition(node_point_t node_pt) {
+    query_point_t extractPosition(const node_point_t& node_pt) {
       static_assert(
                     point_traits<query_point_t>::numDims <=
                     point_traits<node_point_t>::numDims,
                     "dimension of query point must be smaller than or equal to dimension of node point");
       query_point_t res;
       for(int i=0; i<point_traits<query_point_t>::numDims; ++i) {
-        QueryPointInterface::get(res, i) = NodePointInterface::get(node_pt, i);
+        point_traits<query_point_t>::setCoord(
+            res,
+            i,
+            point_traits<node_point_t>::getCoord(node_pt, i));
       }
       return res;
     }
 
   } // ::cukd::common
-
-  using common::point_traits;
-  
-  inline __both__ float getCoord(float3 v, int dim)
-  { return (dim==0)?v.x:((dim==1)?v.y:v.z); }
-  
-  inline __both__ float getCoord(float4 v, int dim)
-  { return (dim==0)?v.x:((dim==1)?v.y:((dim==2)?v.z:v.w)); }
-
-  inline __both__ void setCoord(float3 &v, int dim, float value) {
-    if (dim == 0) v.x = value;
-    if (dim == 1) v.y = value;
-    if (dim == 2) v.z = value;
-  }
-  inline __both__ void setCoord(float4 &v, int dim, float value) {
-    if (dim == 0) v.x = value;
-    if (dim == 1) v.y = value;
-    if (dim == 2) v.z = value;
-    if (dim == 3) v.w = value;
-  }
 
   template<typename scalar_t>
   inline __device__ scalar_t clamp(scalar_t v, scalar_t lo, scalar_t hi)
@@ -362,19 +358,21 @@ namespace cukd {
     itself, otherwise it'll be a point on the outside surface of the
     box */
   template<typename point_t>
-  inline __device__ point_t project(common::box_t<point_t> box, point_t point)
+  inline __device__ point_t project(
+      const common::box_t<point_t>& box,
+      const point_t& point)
   {
     point_t projected;
-    enum { numDims = point_traits<point_t>::numDims };
+    enum { numDims = common::point_traits<point_t>::numDims };
 #pragma unroll
     for (int d=0;d<numDims;d++) {
-      auto lo = getCoord(box.lower,d);
-      auto hi = getCoord(box.upper,d);
-      setCoord(projected,d,clamp(getCoord(point,d),lo,hi));
+      auto lo = common::point_traits<point_t>::getCoord(box.lower,d);
+      auto hi = common::point_traits<point_t>::getCoord(box.upper,d);
+      common::point_traits<point_t>::setCoord(projected,d,clamp(common::point_traits<point_t>::getCoord(point,d),lo,hi));
     }
     return projected;
   }
-  
+
 } // ::cukd
 
 #define CUKD_CUDA_CHECK( call )                                         \


### PR DESCRIPTION
reviewed templates to get rid of the point accessor and folding it into the point_traits. Template everything on the point_traits instead of the point itself.

Note:
- work in progress: haven't touched the test files of knn yet
- tested in my code and it works without any behavioral or timing difference