### PR TITLE
ZipCompare as a host function too

### DIFF
--- a/cukd/builder.h
+++ b/cukd/builder.h
@@ -75,13 +75,13 @@ namespace cukd {
 
   template<typename point_traits_t>
   struct ZipCompare {
-    ZipCompare(const int dim) : dim(dim) {}
+    explicit ZipCompare(const int dim) : dim(dim) {}
 
     /*! the actual comparison operator; will perform a
       'zip'-comparison in that the first element is the major sort
       order, and the second the minor one (for those of same major
       sort key) */
-    inline __device__ bool operator()
+    inline __host__ __device__ bool operator()
     (const thrust::tuple<tag_t, typename point_traits_t::point_t> &a,
      const thrust::tuple<tag_t, typename point_traits_t::point_t> &b);
 
@@ -310,17 +310,17 @@ namespace cukd {
     order, and the second the minor one (for those of same major
     sort key) */
   template<typename point_traits_t>
-  inline __device__
+  inline __host__ __device__
   bool ZipCompare<point_traits_t>::operator()
     (const thrust::tuple<tag_t, typename point_traits_t::point_t> &a,
      const thrust::tuple<tag_t, typename point_traits_t::point_t> &b)
   {
-    const auto tag_a = thrust::get<0>(a);
-    const auto tag_b = thrust::get<0>(b);
-    const auto pnt_a = thrust::get<1>(a);
-    const auto pnt_b = thrust::get<1>(b);
-    const auto dim_a = point_traits_t::getCoord(pnt_a,dim);
-    const auto dim_b = point_traits_t::getCoord(pnt_b,dim);
+    const auto& tag_a = thrust::get<0>(a);
+    const auto& tag_b = thrust::get<0>(b);
+    const auto& pnt_a = thrust::get<1>(a);
+    const auto& pnt_b = thrust::get<1>(b);
+    const auto& dim_a = point_traits_t::getCoord(pnt_a,dim);
+    const auto& dim_b = point_traits_t::getCoord(pnt_b,dim);
     const bool less =
       (tag_a < tag_b)
       ||

--- a/cukd/builder.h
+++ b/cukd/builder.h
@@ -90,7 +90,7 @@ namespace cukd {
 
   /* performs the L-th step's tag update: each input tag refers to a
      subtree ID on level L, and - assuming all points and tags are in
-     the expected sort order described inthe paper - this kernel will
+     the expected sort order described in the paper - this kernel will
      update each of these tags to either left or right child (or root
      node) of given subtree*/
   __global__
@@ -111,8 +111,8 @@ namespace cukd {
     // what the tag stores...
     int subtree = tag[gid];
 
-    // computed the expected positoin of the pivot element for the
-    // given subtree when using our speific array layout.
+    // computed the expected position of the pivot element for the
+    // given subtree when using our specific array layout.
     const int pivotPos = ArrayLayoutInStep(L,numPoints).pivotPosOf(subtree);
 
     if (gid < pivotPos)
@@ -190,7 +190,7 @@ namespace cukd {
     tag_point_iterator end = thrust::make_zip_iterator
       (thrust::make_tuple(tags.end(),points_end));
 
-    /* compute number of levels in the tree, which dicates how many
+    /* compute number of levels in the tree, which dictates how many
        construction steps we need to run */
     const int numLevels = BinaryTree::numLevelsFor(numPoints);
     const int deepestLevel = numLevels-1;
@@ -201,7 +201,7 @@ namespace cukd {
 #endif
 
     /* now build each level, one after another, cycling through the
-       dimensoins */
+       dimensions */
     for (int level=0;level<deepestLevel;level++) {
       thrust::sort(thrust::device.on(stream),begin,end,
                    ZipCompare<data_point_traits_t>((level)%numDims));


### PR DESCRIPTION
Make `ZipCompare` a `__host__` function too.
Also split updateTag into the kernel which updates all the points and the single tag update function.

I did that because I copied and modified buildTree to work on CPU.

I am pretty sure buildTree could be rewritten with some thrust magic to be able to run both on CPU and GPU by simply checking the exec policy but I haven't found a way to do that...