### PR TITLE
Approximate search with eps param

### DIFF
--- a/cukd/fcp.h
+++ b/cukd/fcp.h
@@ -234,7 +234,7 @@ namespace cukd {
     FCPResult result;
     result.clear(sqr(params.cutOffRadius));
     traverse_stack_free<FCPResult,data_t,data_traits>
-      (result,queryPoint,d_nodes,N);
+      (result,queryPoint,d_nodes,N,params.eps);
     return result.returnValue();
   }
 

--- a/cukd/fcp.h
+++ b/cukd/fcp.h
@@ -44,6 +44,11 @@ namespace cukd {
       down on the number of branches to be visited during
       traversal */
     float cutOffRadius = INFINITY;
+
+    /*! Controls when to go down the far branch: only follow a far branch if
+      (1+eps) * D is within the search radius, where D is the distance to the
+      far node. Similar to FLANN eps parameter. */
+    float eps = 0;
   };
 
   namespace stackBased {

--- a/cukd/traverse-stack-free.h
+++ b/cukd/traverse-stack-free.h
@@ -25,11 +25,13 @@ namespace cukd {
   void traverse_stack_free(result_t &result,
                            typename data_traits::point_t queryPoint,
                            const data_t *d_nodes,
-                           int N)
+                           int N,
+                           float eps=0.0f)
   {
     using point_t  = typename data_traits::point_t;
     using scalar_t = typename scalar_type_of<point_t>::type;
     enum { num_dims = num_dims_of<point_t>::value };
+    const auto epsErr = 1 + eps;
 
     scalar_t cullDist = result.initialCullDist2();
     
@@ -77,7 +79,7 @@ namespace cukd {
         // the far side - but only if this exists, and if far half of
         // current space if even within search radius.
         next
-          = ((curr_far_child<N) && (curr_dim_dist * curr_dim_dist < cullDist))
+          = ((curr_far_child<N) && (curr_dim_dist * curr_dim_dist * epsErr < cullDist))
           ? curr_far_child
           : parent;
       else if (prev == curr_far_child)


### PR DESCRIPTION
Reintroducing `eps` in the search params, which was first introduced in #4 and later removed for some reason. Similar to the same param used in FLANN for approximate nearest neighbor, this affects when to search the far branch: it will check the far branch if `far_dist^2 * (1 + eps)` is within the search radius (squared). Therefore, for a non-zero value of eps it will search less far branches, resulting in a speed up of the algorithm.

See https://github.com/flann-lib/flann/blob/f9caaf609d8b8cb2b7104a85cf59eb92c275a25d/doc/manual.tex#L875 and https://github.com/flann-lib/flann/blob/f9caaf609d8b8cb2b7104a85cf59eb92c275a25d/src/cpp/flann/algorithms/kdtree_index.h#L615 for the FLANN equivalent

Notes:
- this is currently only used in the stack free version of FCP.
- benchmarked 15% faster in my test cases (with eps=1)